### PR TITLE
feat: add cover letter page with PDF export and fix project links

### DIFF
--- a/src/pages/cover-letter.astro
+++ b/src/pages/cover-letter.astro
@@ -1,0 +1,139 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { LINKS } from "../lib/constants";
+
+const currentDate = new Date().toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+---
+
+<BaseLayout
+  title="Cover Letter - Susumu Tomita"
+  description="Cover letter of Susumu Tomita - Software Architect & Cloud Engineer"
+>
+  <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24 print:py-8 print:px-0">
+    <!-- Print Button -->
+    <div class="mb-8 flex justify-end gap-3 print:hidden">
+      <button
+        id="printBtn"
+        class="inline-flex items-center gap-2 px-4 py-2 bg-accent-500 hover:bg-accent-600 text-white rounded-lg transition-colors"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        Download PDF
+      </button>
+      <a
+        href="/resume"
+        class="inline-flex items-center gap-2 px-4 py-2 border border-light-border dark:border-dark-border hover:border-accent-500 rounded-lg transition-colors"
+      >
+        View Resume
+      </a>
+    </div>
+
+    <!-- Letter Content -->
+    <div class="bg-white dark:bg-dark-surface print:bg-white p-8 md:p-12 rounded-lg border border-light-border dark:border-dark-border print:border-0 print:p-0">
+      <!-- Header -->
+      <div class="mb-8 print:mb-6">
+        <h1 class="font-display text-2xl md:text-3xl font-bold mb-2 print:text-black">Susumu Tomita</h1>
+        <p class="text-light-muted dark:text-dark-muted print:text-gray-600">
+          Software Architect / Cloud Lead Engineer
+        </p>
+        <div class="flex flex-wrap gap-4 mt-3 text-sm text-light-muted dark:text-dark-muted print:text-gray-600">
+          <span>Tokyo, Japan</span>
+          <span>•</span>
+          <a href={`mailto:${LINKS.email}`} class="hover:text-accent-500">{LINKS.email}</a>
+          <span>•</span>
+          <a href={LINKS.linkedin} class="hover:text-accent-500">LinkedIn</a>
+          <span>•</span>
+          <a href={LINKS.github} class="hover:text-accent-500">GitHub</a>
+        </div>
+      </div>
+
+      <!-- Date -->
+      <p class="mb-8 text-light-muted dark:text-dark-muted print:text-gray-600 print:mb-6">
+        {currentDate}
+      </p>
+
+      <!-- Greeting -->
+      <p class="mb-6 print:text-black">Dear Hiring Manager,</p>
+
+      <!-- Body -->
+      <div class="space-y-4 text-light-text dark:text-dark-text print:text-black leading-relaxed">
+        <p>
+          I am writing to express my strong interest in contributing to your organization as a Software Architect and Cloud Engineer.
+          With over 18 years of experience spanning QA automation, cloud infrastructure, and engineering leadership,
+          I bring a unique perspective that bridges technical excellence with team enablement.
+        </p>
+
+        <p>
+          Throughout my career at Hitachi, DENSO, and various startups, I have consistently delivered impact:
+        </p>
+
+        <ul class="list-disc pl-6 space-y-2">
+          <li>
+            <strong>Cloud Architecture at Scale:</strong> Designed and operated AWS infrastructure for IoT services managing 100K-1M connected devices,
+            achieving high availability for mission-critical automotive applications.
+          </li>
+          <li>
+            <strong>Engineering Culture:</strong> Founded the Cloud Tech Friends (CCoE) community with 2,000+ engineers across DENSO Group,
+            driving cloud adoption and knowledge sharing at enterprise scale.
+          </li>
+          <li>
+            <strong>Quality Engineering:</strong> Built test automation frameworks achieving 80%+ coverage,
+            reducing regression cycles from days to hours while maintaining quality for systems used in banking ATMs and railway IC cards.
+          </li>
+          <li>
+            <strong>Innovation:</strong> Currently working on Web3 infrastructure using Japan's JPKI (Public Key Infrastructure)
+            and lab automation systems for regenerative medicine research.
+          </li>
+        </ul>
+
+        <p>
+          What sets me apart is my ability to see the full picture—from writing robust code to designing scalable systems to fostering team growth.
+          I am passionate about creating environments where engineers can do their best work, whether through better tooling, clearer processes, or hands-on mentorship.
+        </p>
+
+        <p>
+          I am particularly drawn to organizations that value engineering excellence and continuous improvement.
+          I would welcome the opportunity to discuss how my experience in cloud architecture, DevOps practices, and team leadership could contribute to your team's success.
+        </p>
+
+        <p>
+          Thank you for considering my application. I look forward to the possibility of speaking with you.
+        </p>
+      </div>
+
+      <!-- Closing -->
+      <div class="mt-8 print:mt-6">
+        <p class="mb-4 print:text-black">Best regards,</p>
+        <p class="font-display font-semibold text-lg print:text-black">Susumu Tomita</p>
+      </div>
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  @media print {
+    :global(body) {
+      background: white !important;
+      color: black !important;
+    }
+    :global(header),
+    :global(footer),
+    :global(.print\\:hidden) {
+      display: none !important;
+    }
+    :global(.dark) {
+      color-scheme: light;
+    }
+  }
+</style>
+
+<script>
+  document.getElementById("printBtn")?.addEventListener("click", () => {
+    window.print();
+  });
+</script>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -7,14 +7,14 @@ const projects = [
     title: "ZeroKey",
     description: "A distributed execution model separating instruction, execution, and accountability in blockchain systems.",
     tags: ["Blockchain", "Research", "Smart Contracts"],
-    github: "https://github.com/susumutomita",
+    github: "https://github.com/susumutomita/ZeroKeyCI",
     featured: true,
   },
   {
     title: "Slither Claude Integration",
     description: "Integration of Claude AI with Slither static analyzer for enhanced smart contract security analysis.",
     tags: ["Security", "AI", "Solidity"],
-    github: "https://github.com/susumutomita",
+    github: "https://github.com/crytic/slither/pull/2842",
   },
   {
     title: "Portfolio Site",

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -139,9 +139,28 @@ const achievements = [
   title="Resume - Susumu Tomita"
   description="Professional resume of Susumu Tomita - Software Architect & Cloud Engineer"
 >
-  <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24">
+  <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24 print:py-8 print:px-4 print:max-w-none">
+    <!-- Print Controls -->
+    <div class="mb-8 flex justify-end gap-3 print:hidden">
+      <button
+        id="printBtn"
+        class="inline-flex items-center gap-2 px-4 py-2 bg-accent-500 hover:bg-accent-600 text-white rounded-lg transition-colors"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        Download PDF
+      </button>
+      <a
+        href="/cover-letter"
+        class="inline-flex items-center gap-2 px-4 py-2 border border-light-border dark:border-dark-border hover:border-accent-500 rounded-lg transition-colors"
+      >
+        View Cover Letter
+      </a>
+    </div>
+
     <!-- Header -->
-    <div class="mb-16 flex flex-wrap items-start justify-between gap-6">
+    <div class="mb-16 print:mb-8 flex flex-wrap items-start justify-between gap-6">
       <div>
         <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">Susumu Tomita</h1>
         <p class="text-xl text-accent-500 font-medium mb-4">
@@ -313,3 +332,42 @@ const achievements = [
     </section>
   </div>
 </BaseLayout>
+
+<style>
+  @media print {
+    :global(body) {
+      background: white !important;
+      color: black !important;
+      font-size: 11px !important;
+    }
+    :global(header),
+    :global(footer),
+    :global(.print\\:hidden) {
+      display: none !important;
+    }
+    :global(.dark) {
+      color-scheme: light;
+    }
+    :global(.bg-light-surface),
+    :global(.dark .bg-dark-surface) {
+      background: white !important;
+    }
+    :global(.text-light-muted),
+    :global(.dark .text-dark-muted) {
+      color: #666 !important;
+    }
+    :global(.text-accent-500) {
+      color: #2563eb !important;
+    }
+    :global(.border-light-border),
+    :global(.dark .border-dark-border) {
+      border-color: #ddd !important;
+    }
+  }
+</style>
+
+<script>
+  document.getElementById("printBtn")?.addEventListener("click", () => {
+    window.print();
+  });
+</script>


### PR DESCRIPTION
## Summary
- カバーレターページ (`/cover-letter`) を追加
- レジュメとカバーレターにPDFダウンロード機能を追加
- Projectsページのリンクを修正

## Changes
### Cover Letter
- 新しいカバーレターページを `/cover-letter` に作成
- 経歴・スキルのハイライトを記載
- レジュメページへのリンクを追加

### PDF Export
- レジュメとカバーレターに「Download PDF」ボタンを追加
- `window.print()` を使用したブラウザ印刷機能
- 印刷用CSSスタイル（ヘッダー・フッター非表示、背景色調整）

### Project Links Fixed
- ZeroKey: `https://github.com/susumutomita/ZeroKeyCI` に修正
- Slither Claude Integration: `https://github.com/crytic/slither/pull/2842` に修正

## Test plan
- [x] ビルド成功を確認
- [ ] カバーレターページが正常に表示されることを確認
- [ ] PDFダウンロードボタンが動作することを確認
- [ ] Projectsページのリンクが正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated cover letter page with print functionality, responsive design, and contact information
  * Added Download PDF button to resume with View Cover Letter link
  * Enhanced print-friendly styling for improved document formatting

* **Updates**
  * Updated project repository links for ZeroKey and Slither Claude Integration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->