### PR TITLE
fix(netlify): add bun install before build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "bun run build"
+  command = "bun install && bun run build"
   publish = "dist"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- Netlifyビルドエラー修正
- `bun install` をビルド前に実行するよう変更
- esbuildのプラットフォーム依存パッケージ問題を解決

## 原因
bun.lockがmacOSで生成されたため、Linux用の`@esbuild/linux-x64`が含まれていなかった

🤖 Generated with [Claude Code](https://claude.com/claude-code)