### PR TITLE
update: Logomixの在籍期間を2026年4月退社に更新

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -55,9 +55,8 @@ const experiences = [
     company: "Logomix Inc.",
     role: "Software Engineer",
     type: "Lab Automation / SRE",
-    period: "2025.6 - Present",
-    description: "Building fully automated iPS cell cultivation system. Integrating Hamilton STAR liquid handling robots with incubators and observation devices.",
-    highlight: true,
+    period: "2025.6 - 2026.4",
+    description: "Built fully automated iPS cell cultivation system. Integrated Hamilton STAR liquid handling robots with incubators and observation devices.",
   },
   {
     company: "MynaWallet Inc.",

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -34,7 +34,7 @@ const experiences = [
   {
     company: "Logomix Inc.",
     role: "Software Engineer (Lab Automation / SRE)",
-    period: "2025.6 - Present",
+    period: "2025.6 - 2026.4",
     location: "Remote (Freelance)",
     highlights: [
       "Building fully automated iPS cell cultivation system for regenerative medicine research",


### PR DESCRIPTION
## Summary
- 2026年4月にLogomix Inc.を退社したため、`about.astro` と `resume.astro` の在籍期間を `2025.6 - Present` → `2025.6 - 2026.4` に更新
- `about.astro` の Logomix エントリから `highlight: true` を削除し、現職セクションから過去の経歴セクションへ移動
- 説明文を現在進行形 → 過去形に修正

## Test plan
- [ ] `bun run build` が成功することを確認
- [ ] `/about` ページで Logomix が「Past Experience」側に表示されることを確認
- [ ] `/resume` ページで期間が `2025.6 - 2026.4` と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated employment information for Logomix Inc., reclassifying it from a current role to a previous position with an end date of April 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->