### PR TITLE
fix: Cloudflare Pages ビルド失敗の修正 (Netlify アダプタの無条件 import を撤去)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
-import netlify from "@astrojs/netlify";
 import robotsTxt from "astro-robots-txt";
 import UnoCSS from "@unocss/astro";
 import icon from "astro-icon";
@@ -17,6 +16,15 @@ import svelte from "@astrojs/svelte";
 // serves directly. The site has no runtime SSR needs (no Astro.request/cookies,
 // endpoints are build-time), so the static output is equivalent.
 const isCloudflareBuild = Boolean(process.env.CF_PAGES);
+
+// Load the Netlify adapter only for the Netlify (SSR) build. Importing it during
+// the Cloudflare build pulls in @netlify/zip-it-and-ship-it → @vercel/nft, whose
+// bare-specifier ESM resolution breaks in the Pages build environment and crashes
+// config loading ("Unable to load your Astro config"). The static Cloudflare build
+// does not need an adapter, so we skip the import entirely there.
+const netlify = isCloudflareBuild
+	? null
+	: (await import("@astrojs/netlify")).default;
 
 // https://astro.build/config
 export default defineConfig({

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,19 @@
+{
+  // Cloudflare Pages configuration.
+  //
+  // The site builds to a fully static `dist/` (see astro.config.mjs: when
+  // CF_PAGES is set, Astro emits `output: "static"` with no SSR adapter).
+  // Cloudflare injects CF_PAGES=1 automatically during the Pages build, so no
+  // extra env var is needed here.
+  //
+  // Dashboard build settings should be:
+  //   Build command:    bun run build
+  //   Output directory: dist
+  //
+  // `name` is only used for local/CI `wrangler pages deploy`; Git-integrated
+  // builds use the project connected in the Cloudflare dashboard. If you deploy
+  // with the CLI, make this match your Pages project name.
+  "name": "susumutomita-portfolio",
+  "compatibility_date": "2026-06-30",
+  "pages_build_output_dir": "dist"
+}


### PR DESCRIPTION
## 背景 / 症状

Cloudflare Pages のビルドが `astro check` で失敗していた。

```
[astro] Unable to load your Astro config
Cannot find package '.../@netlify/zip-it-and-ship-it/node_modules/@vercel/nft/index.js'
Did you mean to import "@vercel/nft/out/index.js"?
error: script "build" exited with code 1
```

## 原因

`astro.config.mjs` は `CF_PAGES` のとき `output: "static"` / `adapter: undefined`
に切り替える分岐を持っていたが、冒頭の `import netlify from "@astrojs/netlify"`
が **無条件** に評価されていた。この import が `@netlify/zip-it-and-ship-it`
→ `@vercel/nft` を読み込み、ネストされた `@vercel/nft`(`"main": "./out/index.js"`)
の bare-specifier ESM 解決が Cloudflare のビルド環境で失敗し、設定ロードごとクラッシュ
していた(ローカルでは偶然解決できていた)。

static ビルドの Cloudflare では Netlify アダプタは不要。

## 修正

- `@astrojs/netlify` を **動的 import** に変更し、Netlify(SSR)ビルド時のみ読み込む。
  Cloudflare ビルドは壊れた依存チェーンに一切触れなくなる。
- Pages 設定を明示する `wrangler.jsonc` を追加(`pages_build_output_dir: "dist"`)。

## 確認

ローカルで Cloudflare ビルドを再現:

- `CF_PAGES=1` → `output=static / adapter=none`、`bun run build` で 53 ページが
  純 static 出力(`_worker.js` 等の SSR 出力なし)、`astro check` も通過
- 通常(Netlify)→ `output=server / adapter=@astrojs/netlify` を維持

この PR のプレビュービルドで実 Cloudflare 環境での成功を確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)