### PR TITLE
feat: トップCTAを問い合わせフォーム+仕事依頼導線に変更 (#316)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,12 @@
 ---
 import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { LINKS } from "../lib/constants";
+import { LINKS, bullContactFormUrl } from "../lib/constants";
+import { DEFAULT_LANG } from "../lib/i18n";
+
+// Published bilingual inquiry form (#316). Guarded: falls back to mailto: when
+// the form URL is not a concrete published URL. Shared with /contact.
+const contactFormUrl = bullContactFormUrl(DEFAULT_LANG);
 
 const posts = await getCollection("blog");
 const recentPosts = posts
@@ -303,27 +308,39 @@ const featuredWork = [
   <section class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
     <div class="p-8 md:p-12 rounded-2xl bg-gradient-to-br from-accent-500/10 to-accent-600/5 border border-accent-500/20 text-center">
       <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">Let's Build Something Together</h2>
-      <p class="text-light-muted dark:text-dark-muted mb-6 max-w-xl mx-auto">
-        I'm always interested in new opportunities, collaborations, and challenging projects.
-        Feel free to reach out!
+      <p class="text-light-muted dark:text-dark-muted mb-3 max-w-2xl mx-auto">
+        クラウド基盤の構築、コーポレートドメイン・ID移行、IaC・監視・非機能設計を、設計から実装・運用改善まで一気通貫で支援します。
+        アーキテクチャレビューや技術アドバイザリーからのご相談も歓迎です。
+      </p>
+      <p class="text-sm text-light-muted dark:text-dark-muted mb-8 max-w-2xl mx-auto">
+        Cloud foundations, corporate domain &amp; identity migration, IaC, observability and
+        non-functional design &mdash; from design to implementation and operations.
       </p>
       <div class="flex flex-wrap justify-center gap-4">
         <a
-          href={`mailto:${LINKS.email}`}
-          class="inline-flex items-center px-6 py-3 bg-accent-500 hover:bg-accent-600 text-white font-medium rounded-lg transition-colors"
+          href={contactFormUrl || `mailto:${LINKS.email}`}
+          target={contactFormUrl ? "_blank" : undefined}
+          rel={contactFormUrl ? "noopener noreferrer" : undefined}
+          class="inline-flex items-center gap-2 px-6 py-3 bg-accent-500 hover:bg-accent-600 text-white font-medium rounded-lg transition-colors"
         >
-          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
           </svg>
-          Get in Touch
+          お問い合わせフォーム / Start a conversation
         </a>
         <a
-          href="/cover-letter"
-          class="inline-flex items-center px-6 py-3 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 font-medium rounded-lg transition-colors"
+          href="/contact"
+          class="inline-flex items-center gap-2 px-6 py-3 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 font-medium rounded-lg transition-colors"
         >
-          View Cover Letter
+          仕事のご依頼・できること / Work with me
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+          </svg>
         </a>
       </div>
+      <p class="mt-6 text-sm">
+        <a href="/cover-letter" class="text-accent-500 hover:underline">View Cover Letter &rarr;</a>
+      </p>
     </div>
   </section>
 </BaseLayout>


### PR DESCRIPTION
## 背景

トップページ末尾の CTA が

> Let's Build Something Together
> I'm always interested in new opportunities, collaborations, and challenging projects. Feel free to reach out!

と抽象的で、「結局何ができるのか」「どこから依頼すればいいのか」が伝わらなかった。

## 変更

`src/pages/index.astro` の CTA セクションを刷新（#316 の方針に沿う）。

- **提供領域を明記**（日英）: クラウド基盤 / コーポレートドメイン・ID移行 / IaC・監視・非機能設計 / アーキテクチャレビュー・技術アドバイザリー
- **主導線「お問い合わせフォーム / Start a conversation」** → #316 の公開 Google Form（`forms.gle/cHK2onML5vpTonKL8`）を新規タブで開く
  - `bullContactFormUrl(DEFAULT_LANG)` のガード経由。未公開URL時は `mailto:` にフォールバック（既存 /contact と同じ挙動）
- **副導線「仕事のご依頼・できること / Work with me」** → `/contact`（できることの詳細・フォーム・TenkaCloud 導線あり）
- `View Cover Letter` は補助リンクとして残置

## 確認

- `bun run build`（型チェック含む）通過
- `CF_PAGES=1 bun run build`（static）でレンダリング確認:
  - フォームリンク `forms.gle/cHK2onML5vpTonKL8` が出力に存在
  - 新規タブ（`target="_blank"` + `rel="noopener noreferrer"`)
  - `/contact` リンク、各ラベル、Cover Letter リンクを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the homepage call-to-action section with refreshed messaging in Japanese and English.
  * The main contact button now links to a contact form when available, with a fallback to email.
  * Added a secondary link to the contact page and simplified the cover-letter prompt into an inline link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->