### PR TITLE
fix: SEO URLを正式ドメイン www.susumutomita.com に統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Personal portfolio website for Susumu Tomita, built with Astro and deployed on N
 - **Framework**: Astro
 - **Styling**: UnoCSS (Tailwind-like utility classes)
 - **Package Manager**: bun (NOT npm/yarn)
-- **Deployment**: Netlify
+- **Deployment**: Netlify (production, SSR) and Cloudflare Pages (static via `CF_PAGES`)
 - **Language**: TypeScript
 
 ## Commands

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,13 +28,13 @@ const netlify = isCloudflareBuild
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://susumutomita.github.io',
+	site: 'https://susumutomita.netlify.app',
 	integrations: [
 		sitemap(),
 		robotsTxt({
 			sitemap: [
-				"https://susumutomita.github.io/sitemap-index.xml",
-				"https://susumutomita.github.io/sitemap-0.xml",
+				"https://susumutomita.netlify.app/sitemap-index.xml",
+				"https://susumutomita.netlify.app/sitemap-0.xml",
 			],
 		}),
 		solidJs(),

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,13 +28,13 @@ const netlify = isCloudflareBuild
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://susumutomita.netlify.app',
+	site: 'https://www.susumutomita.com',
 	integrations: [
 		sitemap(),
 		robotsTxt({
 			sitemap: [
-				"https://susumutomita.netlify.app/sitemap-index.xml",
-				"https://susumutomita.netlify.app/sitemap-0.xml",
+				"https://www.susumutomita.com/sitemap-index.xml",
+				"https://www.susumutomita.com/sitemap-0.xml",
 			],
 		}),
 		solidJs(),

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -54,6 +54,6 @@
 
   <!-- URL -->
   <text x="1100" y="560" fill="#6c7a80" font-family="system-ui, sans-serif" font-size="20" text-anchor="end">
-    susumutomita.github.io
+    www.susumutomita.com
   </text>
 </svg>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://susumutomita.netlify.app/sitemap-index.xml
+Sitemap: https://www.susumutomita.com/sitemap-index.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://susumutomita.github.io/sitemap-index.xml
+Sitemap: https://susumutomita.netlify.app/sitemap-index.xml

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -22,7 +22,7 @@ export const SITE = {
   name: "Susumu Tomita",
   title: "Susumu Tomita - Software Engineer",
   description: "Software Engineer specializing in blockchain, Web3, and cloud technologies.",
-  url: "https://susumutomita.github.io",
+  url: "https://susumutomita.netlify.app",
 };
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -22,7 +22,7 @@ export const SITE = {
   name: "Susumu Tomita",
   title: "Susumu Tomita - Software Engineer",
   description: "Software Engineer specializing in blockchain, Web3, and cloud technologies.",
-  url: "https://susumutomita.netlify.app",
+  url: "https://www.susumutomita.com",
 };
 
 /**


### PR DESCRIPTION
## 背景

公開の正式版が独自ドメイン **https://www.susumutomita.com** になった。それまで `site` / `SITE.url` は `https://susumutomita.github.io`(404)を指しており、canonical・og:url・hreflang・JSON-LD schema・sitemap・robots がすべて誤ったURLだった。

## 変更（すべて www.susumutomita.com に統一）

| ファイル | 対象 |
|---|---|
| `src/lib/constants.ts` | `SITE.url` — canonical / og:url / ogImage / hreflang / schema の基点 |
| `astro.config.mjs` | `site`(sitemap生成)+ `robotsTxt` の sitemap URL |
| `public/robots.txt` | `Sitemap:` 行 |
| `public/og-image.svg` | OGカードのドメイン表記 |
| `CLAUDE.md` | Deployment に Cloudflare Pages 併記 |

## 確認（`CF_PAGES=1 bun run build`）

- canonical / og:url → `https://www.susumutomita.com/`
- sitemap-0.xml / robots.txt → `www.susumutomita.com`
- `dist` に旧URL(github.io / netlify.app のサイトURL)は残っていない
- 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)