### PR TITLE
chore(projects): TenkaCloud を先頭にし ZeroKey を削除

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -28,19 +28,20 @@ const statusConfig: Record<ProjectStatus, { label: string; class: string }> = {
 
 const projects: Project[] = [
   {
-    title: "ZeroKey",
-    description: "A distributed execution model separating instruction, execution, and accountability in blockchain systems. Research paper with working implementation.",
-    tags: ["Blockchain", "Research", "Threshold Cryptography"],
-    github: "https://github.com/susumutomita/ZeroKeyCI",
+    title: "TenkaCloud",
+    description: "BULL's open-source, multi-tenant platform for running cloud challenges, GameDays, and technical learning events. It is becoming the next pillar of BULL alongside our engineering engagements, and reads as proof of implementation for multi-tenant operations, identity and access, and auditability — the exact problems we solve for clients.",
+    tags: ["AWS", "Multi-tenant", "Platform", "Open Source"],
+    github: BULL.tenkacloud,
+    site: BULL.tenkacloudSite,
     featured: true,
+    featuredLabel: "Featured Product",
     status: "active",
     highlights: [
-      "Novel separation of instruction and execution",
-      "Threshold cryptography (t-of-n) signing",
-      "Formal model with security proofs",
-      "Research paper ready for publication"
+      "Multi-tenant control-plane / application-plane architecture",
+      "Role-based access and SSO for organizers, staff, and participants",
+      "Admin controls and audit trails for accountability",
+      "Operational tooling to run live Battle / Challenge events",
     ],
-    paper: "/papers/zerokey",
   },
   {
     title: "Koto",
@@ -56,22 +57,6 @@ const projects: Project[] = [
       "Position paper published",
     ],
     paper: "/blog/koto-ai-native-ime",
-  },
-  {
-    title: "TenkaCloud",
-    description: "BULL's open-source, multi-tenant platform for running cloud challenges, GameDays, and technical learning events. It is becoming the next pillar of BULL alongside our engineering engagements, and reads as proof of implementation for multi-tenant operations, identity and access, and auditability — the exact problems we solve for clients.",
-    tags: ["AWS", "Multi-tenant", "Platform", "Open Source"],
-    github: BULL.tenkacloud,
-    site: BULL.tenkacloudSite,
-    featured: true,
-    featuredLabel: "Featured Product",
-    status: "active",
-    highlights: [
-      "Multi-tenant control-plane / application-plane architecture",
-      "Role-based access and SSO for organizers, staff, and participants",
-      "Admin controls and audit trails for accountability",
-      "Operational tooling to run live Battle / Challenge events",
-    ],
   },
   {
     title: "Browser from Scratch",


### PR DESCRIPTION
## 変更

- Featured の先頭を **TenkaCloud** に変更（現在の主軸のため）
- **ZeroKey** のカードを削除

## 補足

ZeroKey のカードには `paper: "/papers/zerokey"` が設定されていましたが、**このルートは存在しません**
（論文は `/blog/zerokey-paper`、一覧は `/papers`）。このサイトは存在しないパスでもトップページを
200 で返すため、リンク切れが表に出ていませんでした。カード削除でこの死にリンクも解消されます。

論文そのもの（`src/content/blog/zerokey-paper.md` と `/papers` の一覧項目）は残しています。

## 残っている ZeroKey の記述（今回は触っていません）

- `src/pages/about.astro`: 「Currently working on ZeroKey (threshold cryptography)」
- `src/pages/resume.astro`: 「Published research on ZeroKey authentication system」

現状に合わせるなら別途更新が必要です。

## 確認

- `bun run build` パス
- dev サーバで `/projects` を確認。Featured は TenkaCloud → Koto の順、ZeroKey の出現は 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)