### PR TITLE
fix(i18n): 日本語表記の氏名を「冨田 進」に修正

### DIFF
--- a/src/components/portfolio/ProjectsPage.astro
+++ b/src/components/portfolio/ProjectsPage.astro
@@ -47,10 +47,10 @@ const statusConfig: Record<ProjectStatus, { label: Localized; class: string }> =
 };
 
 const t = {
-  title: { en: "Projects - Susumu Tomita", ja: "プロジェクト - 富田 晋" },
+  title: { en: "Projects - Susumu Tomita", ja: "プロジェクト - 冨田 進" },
   metaDesc: {
     en: "Open source projects and experiments by Susumu Tomita",
-    ja: "富田晋のオープンソースプロジェクトと実験",
+    ja: "冨田進のオープンソースプロジェクトと実験",
   },
   heading: { en: "Projects", ja: "プロジェクト" },
   intro: {

--- a/src/pages/ja/me/about.astro
+++ b/src/pages/ja/me/about.astro
@@ -105,8 +105,8 @@ const certifications = [
 ---
 
 <BaseLayout
-  title="自己紹介 - 富田 晋"
-  description="富田晋について。クラウド基盤、ブロックチェイン、品質エンジニアリングで 18 年以上の経験を持つソフトウェアアーキテクト。"
+  title="自己紹介 - 冨田 進"
+  description="冨田進について。クラウド基盤、ブロックチェイン、品質エンジニアリングで 18 年以上の経験を持つソフトウェアアーキテクト。"
   lang="ja"
   alternates={portfolioAlternates("/about")}
 >
@@ -114,7 +114,7 @@ const certifications = [
     <!-- Hero -->
     <div class="mb-16">
       <p class="text-accent-500 font-medium mb-2">はじめまして</p>
-      <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">富田 晋</h1>
+      <h1 class="font-display text-4xl md:text-5xl font-bold mb-4">冨田 進</h1>
       <p class="text-xl text-light-muted dark:text-dark-muted mb-4">ソフトウェアエンジニア</p>
       <p class="text-light-muted dark:text-dark-muted max-w-2xl">
         品質エンジニアリングから始まり、クラウドアーキテクチャ、そしてブロックチェインへ。

--- a/src/pages/ja/me/index.astro
+++ b/src/pages/ja/me/index.astro
@@ -43,8 +43,8 @@ const featuredWork = [
 ---
 
 <BaseLayout
-  title="富田 晋 — ソフトウェアエンジニア"
-  description="ブロックチェイン研究、大規模クラウドアーキテクチャ、エンジニアリング文化づくり。18 年以上の経験を持つ日本のソフトウェアエンジニア、富田晋のポートフォリオ。"
+  title="冨田 進 — ソフトウェアエンジニア"
+  description="ブロックチェイン研究、大規模クラウドアーキテクチャ、エンジニアリング文化づくり。18 年以上の経験を持つ日本のソフトウェアエンジニア、冨田進のポートフォリオ。"
   lang="ja"
   alternates={portfolioAlternates("")}
 >
@@ -57,7 +57,7 @@ const featuredWork = [
         <span class="text-accent-500">Web3 とクラウドの基盤</span>
       </h1>
       <p class="text-xl md:text-2xl text-light-muted dark:text-dark-muted max-w-3xl">
-        富田晋です。日本を拠点に 18 年以上、ソフトウェアエンジニアとして働いています。
+        冨田進です。日本を拠点に 18 年以上、ソフトウェアエンジニアとして働いています。
         ブロックチェインの研究、大規模なクラウドアーキテクチャ、そしてエンジニアリング文化づくりが専門です。
       </p>
       <div class="flex flex-wrap gap-4 pt-4">

--- a/src/pages/ja/me/resume.astro
+++ b/src/pages/ja/me/resume.astro
@@ -116,15 +116,15 @@ const achievements = [
 ---
 
 <BaseLayout
-  title="経歴 - 富田 晋"
-  description="富田晋の職務経歴。ソフトウェアアーキテクト／クラウドエンジニア。"
+  title="経歴 - 冨田 進"
+  description="冨田進の職務経歴。ソフトウェアアーキテクト／クラウドエンジニア。"
   lang="ja"
   alternates={portfolioAlternates("/resume")}
 >
   <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24">
     <!-- Header -->
     <div class="mb-12">
-      <h1 class="font-display text-4xl md:text-5xl font-bold mb-3">富田 晋</h1>
+      <h1 class="font-display text-4xl md:text-5xl font-bold mb-3">冨田 進</h1>
       <p class="text-xl text-accent-500 mb-4">ソフトウェアアーキテクト / クラウドエンジニア</p>
       <p class="text-light-muted dark:text-dark-muted max-w-3xl">
         品質エンジニアリングから始め、クラウドアーキテクチャ、ブロックチェイン、そしてアジャイルコーチングへ。


### PR DESCRIPTION
日本語ページで氏名の漢字を誤っていました（誤: 富田 晋 → 正: **冨田 進**）。

## 対象

- `src/pages/ja/me/index.astro`
- `src/pages/ja/me/about.astro`
- `src/pages/ja/me/resume.astro`
- `src/components/portfolio/ProjectsPage.astro`（日本語の title / description）

見出し・`<title>`・meta description をすべて修正しています。`grep -rn "富田" src` で残りが無いことを確認済みです。

`bun run build` パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)