### PR TITLE
fix(home): トップページから防御的なメタ文章とコンサル風の構成を削除

### DIFF
--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -130,166 +130,42 @@ export const EVIDENCE: EvidenceItem[] = [
   },
 ];
 
-export interface OutcomeItem {
-  challenge: Localized;
-  action: Localized;
-  result: Localized;
-  evidenceLabel: Localized;
-  href: string;
+export interface ExperienceItem {
+  name: string;
+  detail: Localized;
 }
 
 /**
- * Selected outcomes in challenge → action → result form. Every number links
- * to the public talk or repository that backs it (issue #366: no strong
- * claims without a public source).
+ * Work history as one flat, chronological list; employment details live in
+ * the resume, not on the home page.
  */
-export const OUTCOMES: OutcomeItem[] = [
+export const EXPERIENCE: ExperienceItem[] = [
   {
-    challenge: {
-      en: "Changes to an internal system took up to one month to reach production.",
-      ja: "業務システムの変更が本番へ届くまで最大 1 か月かかっていた。",
-    },
-    action: {
-      en: "Crossed into another department as an internal side job and introduced CI/CD and DevOps practices.",
-      ja: "社内副業として他部門へ越境し、CI/CD と DevOps の実践を導入した。",
-    },
-    result: {
-      en: "Change lead time went from up to a month to ten minutes.",
-      ja: "変更リードタイムを最大 1 か月から 10 分に短縮した。",
-    },
-    evidenceLabel: {
-      en: "DevOpsDays Tokyo 2025 slides",
-      ja: "DevOpsDays Tokyo 2025 講演資料",
-    },
-    href: "https://speakerdeck.com/susumutomita/devopsdaystokyo2025she-nei-fu-ye-teta-bu-men-he-yue-jing-sitejian-etajia-zhi-zai-ding-yi-zui-da-1kayue-noritotaimuwo10fen-niduan-suo-sitadevopsshi-jian",
+    name: "Hitachi, Ltd.",
+    detail: { en: "QA engineer / technical lead (2006–2017)", ja: "QA エンジニア／テクニカルリード（2006–2017）" },
   },
   {
-    challenge: {
-      en: "Connected-car services needed cloud infrastructure that could be developed, operated, and monitored at scale.",
-      ja: "コネクテッドカーサービスには、大規模に開発・運用・監視できるクラウド基盤が必要だった。",
-    },
-    action: {
-      en: "Designed and ran an AWS-native architecture for development, operations, and monitoring.",
-      ja: "AWS のマネージドサービスを軸に、開発・運用・監視の仕組みを設計・運用した。",
-    },
-    result: {
-      en: "Presented the architecture and operational practices at AWS DevDay Tokyo 2019.",
-      ja: "その構成と運用の実践を AWS DevDay Tokyo 2019 で公開した。",
-    },
-    evidenceLabel: {
-      en: "AWS DevDay Tokyo 2019 slides",
-      ja: "AWS DevDay Tokyo 2019 講演資料",
-    },
-    href: "https://speakerdeck.com/susumutomita/aws-native-application-development",
+    name: "Hitachi Vantara (US)",
+    detail: { en: "Software QA specialist (2017–2018)", ja: "ソフトウェア QA スペシャリスト（2017–2018）" },
   },
   {
-    challenge: {
-      en: "An operations team was stuck firefighting, down to “the login screen won’t open” tickets.",
-      ja: "「ログイン画面が開きません」という問い合わせ対応に追われる運用状態だった。",
+    name: "DENSO",
+    detail: {
+      en: "Software architect / cloud lead (2018–2025), agile coach (2026–)",
+      ja: "ソフトウェアアーキテクト／クラウドリード（2018–2025）、アジャイルコーチ（2026–）",
     },
-    action: {
-      en: "Rebuilt the team's way of working with SRE practices.",
-      ja: "SRE の実践を軸に、チームの働き方を作り直した。",
-    },
-    result: {
-      en: "Shared the transformation journey at DevOpsDays Tokyo 2021.",
-      ja: "その改革の軌跡を DevOpsDays Tokyo 2021 で公開した。",
-    },
-    evidenceLabel: {
-      en: "DevOpsDays Tokyo 2021 session",
-      ja: "DevOpsDays Tokyo 2021 セッション",
-    },
-    href: "https://confengine.com/conferences/devopsdays-tokyo-2021/proposal/15172",
   },
   {
-    challenge: {
-      en: "Running realistic cloud competitions and hands-on training takes heavy preparation for every event.",
-      ja: "実践的なクラウド競技・研修は、開催のたびに大きな準備コストがかかる。",
-    },
-    action: {
-      en: "Built TenkaCloud, an open-source multi-tenant platform that deploys competition environments to participants' AWS accounts.",
-      ja: "参加者の AWS アカウントへ競技環境を自動デプロイする、OSS のマルチテナント基盤 TenkaCloud を開発している。",
-    },
-    result: {
-      en: "The platform and its documentation are developed in the open on GitHub.",
-      ja: "基盤とドキュメントを GitHub 上でオープンに開発・公開している。",
-    },
-    evidenceLabel: {
-      en: "TenkaCloud on GitHub",
-      ja: "GitHub の TenkaCloud リポジトリ",
-    },
-    href: BULL.tenkacloud,
-  },
-];
-
-export interface ExperienceGroup {
-  label: Localized;
-  organizations: { name: string; detail: Localized }[];
-}
-
-/**
- * Organizations, with the relationship stated explicitly so logos or names
- * can never read as customer endorsements (issue #366).
- */
-export const EXPERIENCE_GROUPS: ExperienceGroup[] = [
-  {
-    label: { en: "As a full-time employee", ja: "正社員として" },
-    organizations: [
-      {
-        name: "Hitachi, Ltd.",
-        detail: { en: "QA engineer / technical lead (2006–2017)", ja: "QA エンジニア／テクニカルリード（2006–2017）" },
-      },
-      {
-        name: "Hitachi Vantara (US)",
-        detail: { en: "Software QA specialist (2017–2018)", ja: "ソフトウェア QA スペシャリスト（2017–2018）" },
-      },
-      {
-        name: "DENSO",
-        detail: { en: "Software architect / cloud lead (2018–2025)", ja: "ソフトウェアアーキテクト／クラウドリード（2018–2025）" },
-      },
-    ],
+    name: "WHILL",
+    detail: { en: "Cloud application development (2021–2022)", ja: "クラウドアプリケーション開発（2021–2022）" },
   },
   {
-    label: { en: "Under contract / side engagements", ja: "業務委託・複業として" },
-    organizations: [
-      {
-        name: "WHILL",
-        detail: { en: "Cloud application development (2021–2022)", ja: "クラウドアプリケーション開発（2021–2022）" },
-      },
-      {
-        name: "Logomix",
-        detail: { en: "Lab automation / SRE (2025–2026)", ja: "ラボオートメーション／SRE（2025–2026）" },
-      },
-      {
-        name: "MynaWallet",
-        detail: { en: "Web3 infrastructure and security (2025–)", ja: "Web3 インフラ・セキュリティ（2025–）" },
-      },
-      {
-        name: "DENSO",
-        detail: { en: "Agile coach (2026–)", ja: "アジャイルコーチ（2026–）" },
-      },
-    ],
-  },
-];
-
-export interface SpeakingTheme {
-  theme: Localized;
-  events: string[];
-}
-
-/** Consistent themes across talks, rather than a flat list (issue #366). */
-export const SPEAKING_THEMES: SpeakingTheme[] = [
-  {
-    theme: { en: "Cloud infrastructure & IaC", ja: "クラウド基盤・IaC" },
-    events: ["AWS DevDay Tokyo 2019", "HashiTalks: Japan"],
+    name: "Logomix",
+    detail: { en: "Lab automation / SRE (2025–2026)", ja: "ラボオートメーション／SRE（2025–2026）" },
   },
   {
-    theme: { en: "DevOps & organizational change", ja: "DevOps・組織改善" },
-    events: ["DevOpsDays Tokyo 2021 / 2025", "DevOpsDays Taipei", "Scrum Fest Mikawa 2023"],
-  },
-  {
-    theme: { en: "Operations & security", ja: "運用・セキュリティ" },
-    events: ["Cloud Operator Days Tokyo 2022 / 2024"],
+    name: "MynaWallet",
+    detail: { en: "Web3 infrastructure and security (2025–)", ja: "Web3 インフラ・セキュリティ（2025–）" },
   },
 ];
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,14 +4,7 @@ import PublishedBooks from "../components/PublishedBooks.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { BULL, LINKS, bullContactFormUrl } from "../lib/constants";
 import { bullPath, portfolioAlternates } from "../lib/i18n";
-import {
-  EVIDENCE,
-  EXPERIENCE_GROUPS,
-  OUTCOMES,
-  PROFILE,
-  SPEAKING_THEMES,
-  contactPaths,
-} from "../lib/profile";
+import { EVIDENCE, EXPERIENCE, PROFILE, contactPaths } from "../lib/profile";
 import { bullGraph, tenkaCloudSchema } from "../lib/seo";
 
 const lang = "en" as const;
@@ -169,15 +162,11 @@ const paths = contactPaths(lang);
     </div>
   </section>
 
-  <!-- 3. Evidence -->
-  <section id="evidence" class="scroll-mt-20 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-    <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Evidence</p>
-    <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">Verifiable track record</h2>
-    <p class="text-light-muted dark:text-dark-muted max-w-3xl mb-8">
-      Not a self-introduction — each item links to a primary source: the
-      conference platform, the organizer's page, or the published slides.
-    </p>
-    <ul class="grid gap-4 md:grid-cols-2">
+  <!-- 3. Speaking & Writing -->
+  <section id="speaking" class="scroll-mt-20 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+    <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Speaking &amp; Writing</p>
+    <h2 class="font-display text-2xl md:text-3xl font-bold mb-8">Talks &amp; writing</h2>
+    <ul class="grid gap-4 md:grid-cols-2 mb-10">
       {EVIDENCE.map((item) => (
         <li>
           <a
@@ -200,128 +189,60 @@ const paths = contactPaths(lang);
         </li>
       ))}
     </ul>
-  </section>
-
-  <!-- 4. Selected Outcomes -->
-  <section
-    id="outcomes"
-    class="scroll-mt-20 bg-light-surface dark:bg-dark-surface border-y border-light-border dark:border-dark-border"
-  >
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-      <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Selected Outcomes</p>
-      <h2 class="font-display text-2xl md:text-3xl font-bold mb-8">Challenge → Action → Result</h2>
-      <div class="grid gap-6 md:grid-cols-2">
-        {OUTCOMES.map((o) => (
-          <div class="flex h-full flex-col p-6 rounded-lg border border-light-border dark:border-dark-border bg-light-bg dark:bg-dark-bg">
-            <dl class="space-y-3 text-sm">
-              <div>
-                <dt class="font-medium text-light-muted dark:text-dark-muted uppercase text-xs tracking-wide mb-1">Challenge</dt>
-                <dd>{o.challenge[lang]}</dd>
-              </div>
-              <div>
-                <dt class="font-medium text-light-muted dark:text-dark-muted uppercase text-xs tracking-wide mb-1">Action</dt>
-                <dd>{o.action[lang]}</dd>
-              </div>
-              <div>
-                <dt class="font-medium text-light-muted dark:text-dark-muted uppercase text-xs tracking-wide mb-1">Result</dt>
-                <dd class="font-medium">{o.result[lang]}</dd>
-              </div>
-            </dl>
-            <a
-              href={o.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="mt-auto pt-4 text-sm font-medium text-accent-500 hover:text-accent-600 transition-colors"
-            >
-              {o.evidenceLabel[lang]} →
-            </a>
-          </div>
-        ))}
-      </div>
+    <div class="flex flex-wrap gap-4 mb-4">
+      <a
+        href={LINKS.speakerdeck}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
+      >
+        Slides on Speaker Deck
+      </a>
+      <a
+        href={LINKS.sessionize}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
+      >
+        Speaker profile on Sessionize
+      </a>
+      <a
+        href={LINKS.zenn}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
+      >
+        Articles on Zenn
+      </a>
     </div>
-  </section>
-
-  <!-- 5. Selected Experience -->
-  <section id="experience" class="scroll-mt-20 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-    <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Selected Experience</p>
-    <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">Organizations I have worked with</h2>
-    <p class="text-light-muted dark:text-dark-muted max-w-3xl mb-8">
-      Listed by relationship — employment and contract work, not customer
-      endorsements. Details are on the
-      <a href="/about" class="text-accent-500 hover:underline">About</a> and
-      <a href="/resume" class="text-accent-500 hover:underline">Resume</a> pages.
+    <p class="text-sm text-light-muted dark:text-dark-muted">
+      Speaking requests are welcome —
+      <a href="#contact" class="text-accent-500 hover:underline">get in touch</a>.
     </p>
-    <div class="grid gap-6 md:grid-cols-2">
-      {EXPERIENCE_GROUPS.map((group) => (
-        <div class="p-6 rounded-lg border border-light-border dark:border-dark-border">
-          <h3 class="font-display font-semibold text-lg mb-4">{group.label[lang]}</h3>
-          <ul class="space-y-3">
-            {group.organizations.map((org) => (
-              <li class="text-sm">
-                <span class="font-medium">{org.name}</span>
-                <span class="text-light-muted dark:text-dark-muted"> — {org.detail[lang]}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ))}
-    </div>
   </section>
 
-  <!-- 6. Speaking & Writing -->
+  <!-- 4. Experience -->
   <section
-    id="speaking"
+    id="experience"
     class="scroll-mt-20 bg-light-surface dark:bg-dark-surface border-y border-light-border dark:border-dark-border"
   >
     <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-      <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Speaking &amp; Writing</p>
-      <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">One consistent thread</h2>
-      <p class="text-light-muted dark:text-dark-muted max-w-3xl mb-8">
-        Talks and writing revolve around the same themes: cloud infrastructure,
-        IaC, DevOps, security, and organizational improvement.
-      </p>
-      <div class="grid gap-6 md:grid-cols-3 mb-10">
-        {SPEAKING_THEMES.map((t) => (
-          <div class="p-5 rounded-lg border border-light-border dark:border-dark-border bg-light-bg dark:bg-dark-bg">
-            <h3 class="font-display font-semibold mb-3 text-accent-500">{t.theme[lang]}</h3>
-            <ul class="space-y-1 text-sm text-light-muted dark:text-dark-muted">
-              {t.events.map((e) => (
-                <li>{e}</li>
-              ))}
-            </ul>
-          </div>
+      <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Experience</p>
+      <h2 class="font-display text-2xl md:text-3xl font-bold mb-8">Where I've worked</h2>
+      <ul class="max-w-3xl space-y-4">
+        {EXPERIENCE.map((org) => (
+          <li>
+            <span class="font-medium">{org.name}</span>
+            <span class="text-light-muted dark:text-dark-muted"> — {org.detail[lang]}</span>
+          </li>
         ))}
-      </div>
-      <div class="flex flex-wrap gap-4 mb-4">
-        <a
-          href={LINKS.speakerdeck}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
-        >
-          Slides on Speaker Deck
-        </a>
-        <a
-          href={LINKS.sessionize}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
-        >
-          Speaker profile on Sessionize
-        </a>
-        <a
-          href={LINKS.zenn}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
-        >
-          Articles on Zenn
-        </a>
-      </div>
-      <p class="text-sm text-light-muted dark:text-dark-muted">
-        Speaking requests are welcome —
-        <a href="#contact" class="text-accent-500 hover:underline">get in touch</a>.
-      </p>
+      </ul>
+      <a
+        href="/about"
+        class="mt-8 inline-block text-sm font-medium text-accent-500 hover:text-accent-600 transition-colors"
+      >
+        Full background →
+      </a>
     </div>
   </section>
 
@@ -355,35 +276,13 @@ const paths = contactPaths(lang);
     </div>
   </section>
 
-  <!-- 7. About -->
-  <section
-    id="about"
-    class="scroll-mt-20 bg-light-surface dark:bg-dark-surface border-y border-light-border dark:border-dark-border"
-  >
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-      <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">About</p>
-      <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">From QA to cloud, to building how engineers learn</h2>
-      <p class="text-light-muted dark:text-dark-muted max-w-3xl mb-6">
-        I started in QA on mission-critical systems, moved into cloud
-        architecture and SRE for connected services, and kept crossing team
-        boundaries to fix how organizations deliver software. That thread —
-        quality, infrastructure, and people learning by doing — is what led to
-        founding BULL LLC and building TenkaCloud: education that runs on real
-        AWS, not on slides.
-      </p>
-      <a href="/about" class="text-sm font-medium text-accent-500 hover:text-accent-600 transition-colors">
-        Full background →
-      </a>
-    </div>
-  </section>
-
-  <!-- 8. Contact -->
+  <!-- 5. Contact -->
   <section id="contact" class="scroll-mt-20 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
     <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Contact</p>
-    <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">Pick the route that fits</h2>
+    <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">Get in touch</h2>
     <p class="text-light-muted dark:text-dark-muted max-w-3xl mb-8">
-      Each route goes to the right form or page. I read every message and reply
-      by email — no newsletters, no automated follow-ups.
+      For TenkaCloud, cloud infrastructure and DevOps work, or speaking and
+      writing requests.
     </p>
     <div class="grid gap-6 md:grid-cols-2">
       {paths.map((p) => (

--- a/src/pages/ja/me/index.astro
+++ b/src/pages/ja/me/index.astro
@@ -4,14 +4,7 @@ import PublishedBooks from "../../../components/PublishedBooks.astro";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import { BULL, LINKS, bullContactFormUrl } from "../../../lib/constants";
 import { bullPath, portfolioAlternates, portfolioPath } from "../../../lib/i18n";
-import {
-  EVIDENCE,
-  EXPERIENCE_GROUPS,
-  OUTCOMES,
-  PROFILE,
-  SPEAKING_THEMES,
-  contactPaths,
-} from "../../../lib/profile";
+import { EVIDENCE, EXPERIENCE, PROFILE, contactPaths } from "../../../lib/profile";
 import { bullGraph, tenkaCloudSchema } from "../../../lib/seo";
 
 const lang = "ja" as const;
@@ -168,14 +161,11 @@ const paths = contactPaths(lang);
     </div>
   </section>
 
-  <!-- 3. Evidence -->
-  <section id="evidence" class="scroll-mt-20 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-    <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Evidence</p>
-    <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">第三者が確認できる実績</h2>
-    <p class="text-light-muted dark:text-dark-muted max-w-3xl mb-8">
-      自己紹介文ではなく、確認できる証拠を集めています。各項目はカンファレンスのセッションページ、主催者の公式ページ、公開済みの講演資料など、一次情報へリンクしています。
-    </p>
-    <ul class="grid gap-4 md:grid-cols-2">
+  <!-- 3. Speaking & Writing -->
+  <section id="speaking" class="scroll-mt-20 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+    <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Speaking &amp; Writing</p>
+    <h2 class="font-display text-2xl md:text-3xl font-bold mb-8">登壇・執筆</h2>
+    <ul class="grid gap-4 md:grid-cols-2 mb-10">
       {EVIDENCE.map((item) => (
         <li>
           <a
@@ -198,125 +188,59 @@ const paths = contactPaths(lang);
         </li>
       ))}
     </ul>
-  </section>
-
-  <!-- 4. Selected Outcomes -->
-  <section
-    id="outcomes"
-    class="scroll-mt-20 bg-light-surface dark:bg-dark-surface border-y border-light-border dark:border-dark-border"
-  >
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-      <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Selected Outcomes</p>
-      <h2 class="font-display text-2xl md:text-3xl font-bold mb-8">課題 → 対応 → 結果</h2>
-      <div class="grid gap-6 md:grid-cols-2">
-        {OUTCOMES.map((o) => (
-          <div class="flex h-full flex-col p-6 rounded-lg border border-light-border dark:border-dark-border bg-light-bg dark:bg-dark-bg">
-            <dl class="space-y-3 text-sm">
-              <div>
-                <dt class="font-medium text-light-muted dark:text-dark-muted uppercase text-xs tracking-wide mb-1">課題</dt>
-                <dd>{o.challenge[lang]}</dd>
-              </div>
-              <div>
-                <dt class="font-medium text-light-muted dark:text-dark-muted uppercase text-xs tracking-wide mb-1">対応</dt>
-                <dd>{o.action[lang]}</dd>
-              </div>
-              <div>
-                <dt class="font-medium text-light-muted dark:text-dark-muted uppercase text-xs tracking-wide mb-1">結果</dt>
-                <dd class="font-medium">{o.result[lang]}</dd>
-              </div>
-            </dl>
-            <a
-              href={o.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="mt-auto pt-4 text-sm font-medium text-accent-500 hover:text-accent-600 transition-colors"
-            >
-              {o.evidenceLabel[lang]} →
-            </a>
-          </div>
-        ))}
-      </div>
+    <div class="flex flex-wrap gap-4 mb-4">
+      <a
+        href={LINKS.speakerdeck}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
+      >
+        Speaker Deck で資料を見る
+      </a>
+      <a
+        href={LINKS.sessionize}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
+      >
+        Sessionize プロフィール
+      </a>
+      <a
+        href={LINKS.zenn}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
+      >
+        Zenn で記事を読む
+      </a>
     </div>
-  </section>
-
-  <!-- 5. Selected Experience -->
-  <section id="experience" class="scroll-mt-20 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-    <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Selected Experience</p>
-    <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">関わってきた組織</h2>
-    <p class="text-light-muted dark:text-dark-muted max-w-3xl mb-8">
-      顧客推薦ではなく、雇用・業務委託など関係性を明示した一覧です。詳細は
-      <a href={portfolioPath("ja", "/about")} class="text-accent-500 hover:underline">自己紹介</a>と
-      <a href={portfolioPath("ja", "/resume")} class="text-accent-500 hover:underline">経歴</a>のページにあります。
+    <p class="text-sm text-light-muted dark:text-dark-muted">
+      登壇のご依頼は<a href="#contact" class="text-accent-500 hover:underline">お問い合わせ</a>からどうぞ。
     </p>
-    <div class="grid gap-6 md:grid-cols-2">
-      {EXPERIENCE_GROUPS.map((group) => (
-        <div class="p-6 rounded-lg border border-light-border dark:border-dark-border">
-          <h3 class="font-display font-semibold text-lg mb-4">{group.label[lang]}</h3>
-          <ul class="space-y-3">
-            {group.organizations.map((org) => (
-              <li class="text-sm">
-                <span class="font-medium">{org.name}</span>
-                <span class="text-light-muted dark:text-dark-muted"> — {org.detail[lang]}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ))}
-    </div>
   </section>
 
-  <!-- 6. Speaking & Writing -->
+  <!-- 4. Experience -->
   <section
-    id="speaking"
+    id="experience"
     class="scroll-mt-20 bg-light-surface dark:bg-dark-surface border-y border-light-border dark:border-dark-border"
   >
     <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-      <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Speaking &amp; Writing</p>
-      <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">一貫したテーマ</h2>
-      <p class="text-light-muted dark:text-dark-muted max-w-3xl mb-8">
-        登壇も執筆も、クラウド基盤・IaC・DevOps・セキュリティ・組織改善という同じテーマを軸にしています。
-      </p>
-      <div class="grid gap-6 md:grid-cols-3 mb-10">
-        {SPEAKING_THEMES.map((t) => (
-          <div class="p-5 rounded-lg border border-light-border dark:border-dark-border bg-light-bg dark:bg-dark-bg">
-            <h3 class="font-display font-semibold mb-3 text-accent-500">{t.theme[lang]}</h3>
-            <ul class="space-y-1 text-sm text-light-muted dark:text-dark-muted">
-              {t.events.map((e) => (
-                <li>{e}</li>
-              ))}
-            </ul>
-          </div>
+      <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Experience</p>
+      <h2 class="font-display text-2xl md:text-3xl font-bold mb-8">経歴</h2>
+      <ul class="max-w-3xl space-y-4">
+        {EXPERIENCE.map((org) => (
+          <li>
+            <span class="font-medium">{org.name}</span>
+            <span class="text-light-muted dark:text-dark-muted"> — {org.detail[lang]}</span>
+          </li>
         ))}
-      </div>
-      <div class="flex flex-wrap gap-4 mb-4">
-        <a
-          href={LINKS.speakerdeck}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
-        >
-          Speaker Deck で資料を見る
-        </a>
-        <a
-          href={LINKS.sessionize}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
-        >
-          Sessionize プロフィール
-        </a>
-        <a
-          href={LINKS.zenn}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center px-5 py-2.5 border border-light-border dark:border-dark-border hover:border-accent-500 dark:hover:border-accent-500 text-sm font-medium rounded-lg transition-colors"
-        >
-          Zenn で記事を読む
-        </a>
-      </div>
-      <p class="text-sm text-light-muted dark:text-dark-muted">
-        登壇のご依頼は<a href="#contact" class="text-accent-500 hover:underline">お問い合わせ</a>からどうぞ。
-      </p>
+      </ul>
+      <a
+        href={portfolioPath("ja", "/about")}
+        class="mt-8 inline-block text-sm font-medium text-accent-500 hover:text-accent-600 transition-colors"
+      >
+        詳しい経歴を見る →
+      </a>
     </div>
   </section>
 
@@ -350,34 +274,12 @@ const paths = contactPaths(lang);
     </div>
   </section>
 
-  <!-- 7. About -->
-  <section
-    id="about"
-    class="scroll-mt-20 bg-light-surface dark:bg-dark-surface border-y border-light-border dark:border-dark-border"
-  >
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-      <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">About</p>
-      <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">QA からクラウドへ、そして学びの仕組みづくりへ</h2>
-      <p class="text-light-muted dark:text-dark-muted max-w-3xl mb-6">
-        ミッションクリティカルなシステムの QA から始まり、コネクテッドサービスのクラウドアーキテクチャと
-        SRE を経て、部門を越えてソフトウェアの届け方を改善してきました。品質、インフラ、そして「手を動かして学ぶ」こと。この一本の軸が、合同会社
-        BULL の設立と、スライドではなく実 AWS で学ぶ TenkaCloud の開発につながっています。
-      </p>
-      <a
-        href={portfolioPath("ja", "/about")}
-        class="text-sm font-medium text-accent-500 hover:text-accent-600 transition-colors"
-      >
-        詳しい経歴を見る →
-      </a>
-    </div>
-  </section>
-
-  <!-- 8. Contact -->
+  <!-- 5. Contact -->
   <section id="contact" class="scroll-mt-20 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
     <p class="text-accent-500 font-medium tracking-wide uppercase text-sm mb-3">Contact</p>
-    <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">目的に合わせた窓口</h2>
+    <h2 class="font-display text-2xl md:text-3xl font-bold mb-4">お問い合わせ</h2>
     <p class="text-light-muted dark:text-dark-muted max-w-3xl mb-8">
-      それぞれの窓口から適切なフォーム・ページへつながります。いただいた内容はすべて目を通し、メールで返信します。ニュースレターへの自動登録などは行いません。
+      TenkaCloud の導入相談、クラウド基盤・DevOps の支援、登壇・執筆のご依頼はこちらから。
     </p>
     <div class="grid gap-6 md:grid-cols-2">
       {paths.map((p) => (


### PR DESCRIPTION
## 概要

PR #367 の再設計で入った、訪問者向けに編集方針を語る防御的なコピーとコンサル資料風の構成をトップページ(英語版 `/`・日本語版 `/ja/me/`)から撤去し、普通のポートフォリオ構成に戻す。

## 変更内容

- 「顧客推薦ではなく〜」「自己紹介文ではなく〜」等の断り書きを全て削除
- Evidence と Speaking & Writing を「登壇・執筆」1 セクションに統合(登壇カード+Speaker Deck / Sessionize / Zenn リンク)
- 経歴の「正社員として/業務委託・複業として」グループ分けを廃止し、組織名・役割・期間だけのフラットな一覧に。雇用形態の表記は職務経歴書に委ね、トップページには載せない
- Selected Outcomes(課題→対応→結果)セクションを削除
- About 語りセクションを削除し、経歴セクション末尾の「詳しい経歴を見る →」リンクに集約
- Contact を「目的に合わせた窓口」→「お問い合わせ」+一文の案内に簡素化
- `profile.ts` から未使用になった `OUTCOMES` / `SPEAKING_THEMES` / `EXPERIENCE_GROUPS` を削除

## 確認

- `bun run build`(型チェック込み)通過
- ビルド成果物に旧文言が残っていないこと(grep)を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)